### PR TITLE
Delay no-repo message until repository loading finishes

### DIFF
--- a/Omny.Cms.Ui.Tests/Editor/EditorPageTests.cs
+++ b/Omny.Cms.Ui.Tests/Editor/EditorPageTests.cs
@@ -10,6 +10,7 @@ using NUnit.Framework;
 using System.Collections.Generic;
 using Omny.Cms.Manifest;
 using Omny.Cms.UiRepositories.Files.GitHub;
+using Omny.Cms.UiRepositories.Models;
 
 namespace Omny.Cms.Ui.Tests.Editor;
 
@@ -45,9 +46,11 @@ public class EditorPageTests
         ctx.Services.AddSingleton(Mock.Of<IRemoteFileService>());
         ctx.Services.AddSingleton(Mock.Of<IPluginRegistry>());
         ctx.Services.AddSingleton(Mock.Of<IAdvancedUserCheck>());
-        var repoMgr = Mock.Of<IRepositoryManagerService>();
-        ctx.Services.AddSingleton(repoMgr);
-        ctx.Services.AddSingleton(new BuildWatcherService(Mock.Of<IGitHubClientProvider>(), repoMgr));
+        var repoMgr = new Mock<IRepositoryManagerService>();
+        repoMgr.Setup(r => r.GetCurrentRepositoryAsync())
+            .ReturnsAsync(new RepositoryInfo());
+        ctx.Services.AddSingleton<IRepositoryManagerService>(repoMgr.Object);
+        ctx.Services.AddSingleton(new BuildWatcherService(Mock.Of<IGitHubClientProvider>(), repoMgr.Object));
 
         var cut = ctx.RenderComponent<Omny.Cms.UiEditor.Pages.Editor>();
 

--- a/Omny.Cms.Ui/Editor/Pages/Editor.razor
+++ b/Omny.Cms.Ui/Editor/Pages/Editor.razor
@@ -18,7 +18,7 @@
     </div>
 }
 
-@if (_currentRepo == null)
+@if (_currentRepo == null && !_isRepositoryLoading)
 {
     <div class="editor-container">
         <div class="editor-main" style="text-align: center; padding: 2rem;">
@@ -27,6 +27,14 @@
             <MudText Typo="Typo.body1" Color="Color.Secondary">
                 Please add a repository to start editing content.
             </MudText>
+        </div>
+    </div>
+}
+else if (_currentRepo == null)
+{
+    <div class="editor-container">
+        <div class="editor-main" style="text-align: center; padding: 2rem;">
+            <MudProgressCircular Indeterminate Size="Size.Large" />
         </div>
     </div>
 }

--- a/Omny.Cms.Ui/Editor/Pages/Editor.razor.cs
+++ b/Omny.Cms.Ui/Editor/Pages/Editor.razor.cs
@@ -42,14 +42,17 @@ public class EditorBase : ComponentBase, IDisposable
     protected Dictionary<string, List<ContentItem>> _contentTypesMap = new();
     protected RepositoryInfo? _currentRepo;
     protected string _searchTerm = string.Empty;
+    protected bool _isRepositoryLoading = true;
 
     protected override async Task OnInitializedAsync()
     {
         _currentRepo = await RepositoryManager.GetCurrentRepositoryAsync();
-        
+
         // Subscribe to repository changes to reinitialize when a repository is added
         RepositoryManager.CurrentRepositoryChanged += OnRepositoryChanged;
-        
+
+        _isRepositoryLoading = false;
+
         // Don't initialize editor if no repository is configured
         if (_currentRepo == null)
         {


### PR DESCRIPTION
## Summary
- avoid flashing "No Repository Configured" until repository data loads
- show progress indicator while repository information loads
- update editor page test to supply a repository

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68ab5bf23e44832f8239294da709d06c