### PR TITLE
Improve build watcher error reporting and snackbar notifications

### DIFF
--- a/Omny.Cms.Ui/Repositories/Components/RepositorySelector.razor
+++ b/Omny.Cms.Ui/Repositories/Components/RepositorySelector.razor
@@ -6,20 +6,9 @@
 <div class="repository-selector">
 @if (IsFreeVersion)
 {
-    if (!string.IsNullOrEmpty(BuildWatcher.Status))
+    if (currentRepository?.HasWorkflowDispatch == true)
     {
-        if (BuildWatcher.CurrentBuildUrl != null)
-        {
-            <a class="update-link" href="@BuildWatcher.CurrentBuildUrl" target="_blank">@BuildWatcher.Status</a>
-        }
-        else
-        {
-            <button class="update-link" disabled>@BuildWatcher.Status</button>
-        }
-    }
-    else if (currentRepository?.HasWorkflowDispatch == true)
-    {
-        <button class="update-link" @onclick="TriggerUpdate">Update Site</button>
+        <button class="update-link" @onclick="TriggerUpdate" disabled="@BuildWatcher.IsUpdating">Update Site</button>
     }
     <label for="repository-dropdown">Site:</label>
     <select id="repository-dropdown" @onchange="OnRepositoryChanged" value="@GetCurrentRepositoryId()">
@@ -39,20 +28,9 @@
 }
 else
 {
-    if (!string.IsNullOrEmpty(BuildWatcher.Status))
+    if (currentRepository?.HasWorkflowDispatch == true)
     {
-        if (BuildWatcher.CurrentBuildUrl != null)
-        {
-            <a class="update-link" href="@BuildWatcher.CurrentBuildUrl" target="_blank">@BuildWatcher.Status</a>
-        }
-        else
-        {
-            <button class="update-link" disabled>@BuildWatcher.Status</button>
-        }
-    }
-    else if (currentRepository?.HasWorkflowDispatch == true)
-    {
-        <button class="update-link" @onclick="TriggerUpdate">Update Site</button>
+        <button class="update-link" @onclick="TriggerUpdate" disabled="@BuildWatcher.IsUpdating">Update Site</button>
     }
     <label for="repository-dropdown">Site:</label>
     <select id="repository-dropdown" @onchange="OnRepositoryChanged" value="@GetCurrentRepositoryId()">

--- a/Omny.Cms.Ui/Repositories/Components/RepositorySelector.razor.cs
+++ b/Omny.Cms.Ui/Repositories/Components/RepositorySelector.razor.cs
@@ -15,6 +15,7 @@ public class RepositorySelectorBase : ComponentBase, IDisposable
 
     protected List<RepositoryInfo>? repositories;
     protected RepositoryInfo? currentRepository;
+    private string? _lastStatus;
 
     protected static bool IsFreeVersion =>
 #if FREE_VERSION
@@ -34,7 +35,6 @@ public class RepositorySelectorBase : ComponentBase, IDisposable
 #endif
         RepositoryManager.CurrentRepositoryChanged += OnCurrentRepositoryChanged;
         BuildWatcher.StatusChanged += OnBuildStatusChanged;
-        BuildWatcher.BuildCompleted += OnBuildCompleted;
         StateHasChanged();
     }
 
@@ -64,7 +64,29 @@ public class RepositorySelectorBase : ComponentBase, IDisposable
 
     private void OnBuildStatusChanged()
     {
-        InvokeAsync(StateHasChanged);
+        InvokeAsync(() =>
+        {
+            if (BuildWatcher.Status != _lastStatus && !string.IsNullOrEmpty(BuildWatcher.Status))
+            {
+                var severity = BuildWatcher.Status switch
+                {
+                    "Update Completed" => Severity.Success,
+                    "Update Failed" => Severity.Error,
+                    "Updating Site" => Severity.Info,
+                    _ => Severity.Info
+                };
+                Snackbar.Add(BuildWatcher.Status, severity, options =>
+                {
+                    if (BuildWatcher.CurrentBuildUrl != null)
+                    {
+                        options.Action = "View build";
+                        options.ActionHref = BuildWatcher.CurrentBuildUrl;
+                    }
+                });
+                _lastStatus = BuildWatcher.Status;
+            }
+            StateHasChanged();
+        });
     }
 
     protected async Task OnRepositoryChanged(ChangeEventArgs e)
@@ -114,15 +136,9 @@ public class RepositorySelectorBase : ComponentBase, IDisposable
         await BuildWatcher.TriggerWorkflowAsync();
     }
 
-    private void OnBuildCompleted()
-    {
-        Snackbar.Add("Site updated", Severity.Success);
-    }
-
     public void Dispose()
     {
         RepositoryManager.CurrentRepositoryChanged -= OnCurrentRepositoryChanged;
         BuildWatcher.StatusChanged -= OnBuildStatusChanged;
-        BuildWatcher.BuildCompleted -= OnBuildCompleted;
     }
 }


### PR DESCRIPTION
## Summary
- Flag failed workflow runs as build failures
- Move deployment status and build link to snackbar notifications
- Keep Update Site button always labeled and disable during updates

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68abb4185140832f95188d33082af701