### PR TITLE
Detect system dark mode via MudThemeProvider

### DIFF
--- a/Omny.Cms.Ui/Layout/MainLayout.razor
+++ b/Omny.Cms.Ui/Layout/MainLayout.razor
@@ -18,7 +18,7 @@
 
         <article class="content px-4">
             @* Required *@
-            <MudThemeProvider />
+            <MudThemeProvider @ref="_mudThemeProvider" @bind-IsDarkMode="_isDarkMode" />
             <MudPopoverProvider />
 
             @* Needed for dialogs *@

--- a/Omny.Cms.Ui/Layout/MainLayout.razor.cs
+++ b/Omny.Cms.Ui/Layout/MainLayout.razor.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
 using Octokit.Internal;
 using Omny.Cms.Ui.Authentication;
+using MudBlazor;
 
 namespace Omny.Cms.UiLayout;
 
@@ -14,6 +15,8 @@ public class MainLayoutBase : LayoutComponentBase
     [Inject] private CsrfTokenProvider? CsrfTokenProvider { get; set; }
 
     protected bool Loaded = false;
+    protected MudThemeProvider? _mudThemeProvider;
+    protected bool _isDarkMode;
 
     protected override async Task OnInitializedAsync()
     {
@@ -48,6 +51,16 @@ public class MainLayoutBase : LayoutComponentBase
 #else
         NavigationManager!.NavigateTo("/Account/Logout", forceLoad: true);
 #endif
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        await base.OnAfterRenderAsync(firstRender);
+        if (firstRender && _mudThemeProvider != null)
+        {
+            _isDarkMode = await _mudThemeProvider.GetSystemDarkModeAsync();
+            StateHasChanged();
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- set MainLayout to use MudThemeProvider to automatically respect system dark mode preferences
- update code-behind to detect dark mode on first render and toggle theme state

## Testing
- `dotnet test Omny.Cms.slnx` *(fails: System.Text.Json.JsonException)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd95b4970832f9fe02ed6b9afaad8