### PR TITLE
Pass page path to page plugins

### DIFF
--- a/Omny.Cms.Abstractions/Rendering/IPagePlugin.cs
+++ b/Omny.Cms.Abstractions/Rendering/IPagePlugin.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using Omny.Cms.Editor;
+using Omny.Cms.Manifest;
+
+namespace Omny.Cms.Rendering;
+
+public interface IPagePlugin
+{
+    string Name { get; }
+
+    Dictionary<string, string> Render(ContentItem contentItem, OmnyManifest manifest, string pagePath);
+}

--- a/Omny.Cms.Builder/ServiceCollectionExtensions.cs
+++ b/Omny.Cms.Builder/ServiceCollectionExtensions.cs
@@ -8,6 +8,7 @@ using Omny.Cms.Plugins.Page;
 using Omny.Cms.Plugins.Menu;
 using Omny.Cms.Plugins.Hexo;
 using Omny.Cms.Rendering.ContentRendering;
+using Omny.Cms.Rendering;
 
 namespace Omny.Cms.Builder;
 
@@ -45,6 +46,13 @@ public static class ServiceCollectionExtensions
             .Where(t => typeof(IContentTypePlugin).IsAssignableFrom(t) && t.IsClass && !t.IsAbstract))
         {
             services.AddSingleton(typeof(IContentTypePlugin), pluginType);
+        }
+
+        foreach (var pluginType in assembly
+            .GetTypes()
+            .Where(t => typeof(IPagePlugin).IsAssignableFrom(t) && t.IsClass && !t.IsAbstract))
+        {
+            services.AddSingleton(typeof(IPagePlugin), pluginType);
         }
 
         return services;


### PR DESCRIPTION
## Summary
- include the page output path when invoking page plugins
- propagate the renderer's computed page path into plugin replacement logic
- adjust builder tests to verify the path is available in plugin output

## Testing
- DOTNET_CLI_DISABLE_TERMINAL_LOGGER=1 dotnet test Omny.Cms.slnx --logger "console;verbosity=minimal" *(fails because MSBuild terminal logger throws ArgumentOutOfRangeException in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f299afefc832f89c04235a31c6e43)