### PR TITLE
Switch to OpenAPI and Scalar

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -29,7 +29,7 @@
     <PackageVersion Include="NUnit" Version="3.13.3" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageVersion Include="Octokit" Version="14.0.0" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="1.0.0" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta5.25306.1" />
     <PackageVersion Include="TinyMCE.Blazor" Version="2.1.0" />
     <PackageVersion Include="YamlDotNet" Version="13.1.0" />

--- a/Omny.Cms.Api/Omny.Cms.Api.csproj
+++ b/Omny.Cms.Api/Omny.Cms.Api.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="Auth0.AspNetCore.Authentication" />
         <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
-        <PackageReference Include="Swashbuckle.AspNetCore" />
+        <PackageReference Include="Scalar.AspNetCore" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
     </ItemGroup>

--- a/Omny.Cms.Api/Program.cs
+++ b/Omny.Cms.Api/Program.cs
@@ -8,13 +8,12 @@ using Omny.Api;
 using Omny.Api.Auth;
 using WebApplication1;
 using Omny.Cms.Api.Extensions;
+using Scalar.AspNetCore;
 
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
-// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
-builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
+builder.Services.AddOpenApi();
 builder.Services.AddAuthentication();
 
 bool hasAuth0Config = builder.Configuration.GetSection("Auth0").Exists() &&
@@ -103,8 +102,8 @@ if (builder.Configuration.GetValue<string>("OverrideHost") is { } overrideHost)
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {
-    app.UseSwagger();
-    app.UseSwaggerUI();
+    app.MapOpenApi();
+    app.MapScalarUi();
 }
 
 app.UseAuthentication();


### PR DESCRIPTION
## Summary
- replace Swashbuckle usage with the built-in OpenAPI service and Scalar UI
- update package references to remove Swashbuckle and add Scalar.AspNetCore

## Testing
- dotnet build Omny.Cms.Api/Omny.Cms.Api.csproj


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f61472640832f9603ea10a849008e)